### PR TITLE
Migrate from MCJIT to ORC JIT

### DIFF
--- a/dependencies/llvm/CMakeLists.txt
+++ b/dependencies/llvm/CMakeLists.txt
@@ -53,7 +53,7 @@ endif ()
 # Create options for including or excluding LLVM backends.
 ##
 
-set(active_components mcjit bitwriter linker passes)
+set(active_components orcjit bitwriter linker passes)
 set(known_components AArch64 AMDGPU ARM Hexagon Mips NVPTX PowerPC RISCV WebAssembly X86)
 
 foreach (comp IN LISTS known_components)

--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -37,7 +37,9 @@
 #include <llvm/Bitcode/BitcodeWriter.h>
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
 #include <llvm/ExecutionEngine/JITEventListener.h>
-#include <llvm/ExecutionEngine/MCJIT.h>
+#include <llvm/ExecutionEngine/Orc/LLJIT.h>
+#include <llvm/ExecutionEngine/Orc/Core.h>
+#include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
 #include <llvm/IR/Constant.h>
 #include <llvm/IR/Constants.h>


### PR DESCRIPTION
Current log:

<details>
<summary>Test app</summary>

```cpp
#include "Halide.h"

using namespace Halide;

static int sz = 5;

int main(int argc, char** argv) {
    Func brighter("brighter");
    Var x("x"), y("y");

    Buffer<uint8_t> input(sz, sz);
    for (int j = 0; j < input.height(); j++) {
        for (int i = 0; i < input.width(); i++) {
            input(i, j) = i + j;
            std::cout << (int)input(i, j) << " ";
        }
        std::cout << std::endl;
    }
    std::cout << std::endl;

    brighter(x, y) = input(x, y) * 2;

    brighter.bound(x, 0, sz).bound(y, 0, sz);

    Target target = get_host_target();
    std::cout << target << std::endl;

    brighter.print_loop_nest();

    Buffer<uint8_t> output(sz, sz);
    try {
        brighter.realize(output, target);
    } catch(Halide::InternalError& ex) {
        std::cout << ex.what() << std::endl;
    }
    std::cout << "FINISHED!!!!!!!!!!!!!!!!!" << std::endl;

    for (int j = 0; j < output.height(); j++) {
        for (int i = 0; i < output.width(); i++) {
            std::cout << (int)output(i, j) << " ";
        }
        std::cout << std::endl;
    }
    std::cout << std::endl;
}
```

</details>
